### PR TITLE
fix PromfetcherTooManyFailureDuringFetch alert

### DIFF
--- a/jobs/promfetcher_alerts/templates/promfetcher.alerts.yml
+++ b/jobs/promfetcher_alerts/templates/promfetcher.alerts.yml
@@ -12,7 +12,7 @@ groups:
           description: "Promfetcher cannot retrieve gorouter route table at instance `{{$labels.instance}}` during the last <%= p('promfetcher_alerts.scrape_routes_error.evaluation_time') %>"
 
       - alert: PromfetcherTooManyFailureDuringFetch
-        expr: sum(rate(promfetch_metric_fetch_failed_total[10m])) by (instance, organization_name, space_name, app_name, index) > <%= p('promfetcher_alerts.errors.threshold') %>
+        expr: (count(promfetch_metric_fetch_failed_by_app > 0) / count(promfetch_metric_fetch_failed_by_app)) > 0.1
         for: <%= p('promfetcher_alerts.errors.evaluation_time') %>
         labels:
           service: promfetcher

--- a/manifests/operations/prometheus/monitor-promfetcher.yml
+++ b/manifests/operations/prometheus/monitor-promfetcher.yml
@@ -30,6 +30,17 @@
     /var/vcap/jobs/promfetcher_alerts/*.alerts.yml
 
 - type: replace
+  path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties/prometheus/custom_rules?/-
+  value:
+    name: 
+    rules:
+      - record: promfetch_metric_fetch_failed_by_app
+        expr: |
+          sum by(organization_name, space_name, app_name) (rate(promfetch_metric_fetch_failed_total[10m]))
+
+
+
+- type: replace
   path: /releases/-
   value:
     name: promfetcher


### PR DESCRIPTION
The PromfetcherTooManyFailureDuringFetch alert is triggered when 10% of the applications are in error.